### PR TITLE
Avoid math error when formatting values for display

### DIFF
--- a/resources/lcapy/process-circuit.py
+++ b/resources/lcapy/process-circuit.py
@@ -265,6 +265,9 @@ def generate_js_code(analysis_results, input_file, frontmatter, js_dir=None, ove
         sorted_components = sort_symbols(frontmatter['components'].keys())
         for component in sorted_components:
             value = frontmatter['components'][component]
+            if value == 0.0:
+                raise ValueError(f"Invalid component {component} can't have value {value}")
+
             # Format component values with exponent in multiples of 3
             exponent = int(math.log10(abs(value)))
             mantissa = value / (10 ** exponent)

--- a/resources/lcapy/process-circuit.py
+++ b/resources/lcapy/process-circuit.py
@@ -266,8 +266,8 @@ def generate_js_code(analysis_results, input_file, frontmatter, js_dir=None, ove
         for component in sorted_components:
             value = frontmatter['components'][component]
             if value == 0.0:
-                raise ValueError(f"Invalid component {component} can't have value {value}")
-
+                definition += f"{idt4}{component}: 0,\n"
+                continue
             # Format component values with exponent in multiples of 3
             exponent = int(math.log10(abs(value)))
             mantissa = value / (10 ** exponent)


### PR DESCRIPTION
Zero in a component value will cause MathDomainError when we normalize exponents to multiples of 3 for nice-looking component values in the generated js. Does not seem to be an issue anywhere else, this doesn't indicate a problem with the circuit.  Zero needs no normalizing for display, so we just don't :)